### PR TITLE
Read spring.config.location instead of a property that does not exist

### DIFF
--- a/base/src/main/java/ai/javaclaw/configuration/ConfigurationManager.java
+++ b/base/src/main/java/ai/javaclaw/configuration/ConfigurationManager.java
@@ -23,7 +23,7 @@ public class ConfigurationManager {
 
     public ConfigurationManager(Environment environment, ApplicationEventPublisher eventPublisher) {
         this.eventPublisher = eventPublisher;
-        this.configPath = resolveConfigPath(environment.getProperty("spring.allConfig.location"));
+        this.configPath = resolveConfigPath(environment.getProperty("spring.config.location"));
     }
 
     public void updateProperty(String key, Object value) throws IOException {

--- a/base/src/test/java/ai/javaclaw/configuration/ConfigurationManagerTest.java
+++ b/base/src/test/java/ai/javaclaw/configuration/ConfigurationManagerTest.java
@@ -1,0 +1,150 @@
+package ai.javaclaw.configuration;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.mock.env.MockEnvironment;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ConfigurationManagerTest {
+
+    @TempDir
+    Path configDir;
+
+    private final List<Object> publishedEvents = new ArrayList<>();
+    private final ApplicationEventPublisher eventPublisher = publishedEvents::add;
+
+    private ConfigurationManager managerAt(String configLocation) {
+        MockEnvironment environment = new MockEnvironment();
+        if (configLocation != null) {
+            environment.setProperty("spring.config.location", configLocation);
+        }
+        return new ConfigurationManager(environment, eventPublisher);
+    }
+
+    // -----------------------------------------------------------------------
+    // spring.config.location is honoured when resolving the config file
+    //
+    // Every assertion below keys off MARKER, which only ever exists in the
+    // per-test temporary directory. Asserting on a property the real
+    // application.private.yaml also carries would let these tests pass by
+    // reading the fallback location instead of the configured one.
+    // -----------------------------------------------------------------------
+
+    private static final String MARKER = "javaclaw-configuration-manager-test";
+
+    private Path seedConfigFile(String fileName) throws IOException {
+        Path configFile = configDir.resolve(fileName);
+        Files.writeString(configFile, "marker: " + MARKER + "\n");
+        return configFile;
+    }
+
+    @Test
+    void readsFromTheLocationPointingAtAFile() throws IOException {
+        Path configFile = seedConfigFile("application.private.yaml");
+
+        Map<String, Object> config = managerAt(configFile.toString()).readApplicationYaml();
+
+        assertThat(config).containsEntry("marker", MARKER);
+    }
+
+    @Test
+    void readsFromTheLocationPointingAtADirectory() throws IOException {
+        seedConfigFile("application.private.yaml");
+
+        Map<String, Object> config = managerAt(configDir.toString()).readApplicationYaml();
+
+        assertThat(config).containsEntry("marker", MARKER);
+    }
+
+    @Test
+    void stripsTheFilePrefixFromTheLocation() throws IOException {
+        Path configFile = seedConfigFile("application.private.yaml");
+
+        Map<String, Object> config = managerAt("file:" + configFile).readApplicationYaml();
+
+        assertThat(config).containsEntry("marker", MARKER);
+    }
+
+    @Test
+    void usesTheFirstEntryOfACommaSeparatedLocationList() throws IOException {
+        Path configFile = seedConfigFile("application.private.yaml");
+
+        Map<String, Object> config = managerAt(configFile + ",classpath:/other.yaml").readApplicationYaml();
+
+        assertThat(config).containsEntry("marker", MARKER);
+    }
+
+    // -----------------------------------------------------------------------
+    // Writing goes to the same place reading does
+    // -----------------------------------------------------------------------
+
+    @Test
+    void writesToTheConfiguredLocation() throws IOException {
+        ConfigurationManager manager = managerAt(configDir.toString());
+
+        manager.updateProperty("agent.onboarding.completed", true);
+
+        Path written = configDir.resolve("application.private.yaml");
+        assertThat(written).exists();
+        assertThat(Files.readString(written)).contains("completed: true");
+    }
+
+    @Test
+    void writesNestedKeysWithoutDiscardingSiblings() throws IOException {
+        ConfigurationManager manager = managerAt(configDir.toString());
+
+        manager.updateProperty("spring.ai.model.chat", "ollama");
+        manager.updateProperty("spring.ai.ollama.chat.options.model", "gemma4:12b");
+
+        Map<String, Object> reloaded = manager.readApplicationYaml();
+        assertThat(reloaded).containsKey("spring");
+        String written = Files.readString(configDir.resolve("application.private.yaml"));
+        assertThat(written).contains("chat: ollama").contains("model: gemma4:12b");
+    }
+
+    @Test
+    void updatesSeveralPropertiesInASingleWrite() throws IOException {
+        ConfigurationManager manager = managerAt(configDir.toString());
+
+        manager.updateProperties(Map.of("agent.onboarding.completed", true, "spring.ai.model.chat", "ollama"));
+
+        String written = Files.readString(configDir.resolve("application.private.yaml"));
+        assertThat(written).contains("completed: true").contains("chat: ollama");
+        assertThat(publishedEvents).hasSize(1);
+    }
+
+    @Test
+    void publishesAConfigurationChangedEventOnEveryWrite() throws IOException {
+        ConfigurationManager manager = managerAt(configDir.toString());
+
+        manager.updateProperty("agent.onboarding.completed", true);
+
+        assertThat(publishedEvents).hasSize(1).allSatisfy(event ->
+                assertThat(event).isInstanceOf(ConfigurationChangedEvent.class));
+    }
+
+    // -----------------------------------------------------------------------
+    // First run, before any config file has been written
+    //
+    // This covers a configured location whose file does not exist yet. The
+    // separate branch where no location is configured at all resolves to a
+    // hardcoded path inside the source tree, so it cannot be asserted without
+    // writing there; it is left uncovered on purpose.
+    // -----------------------------------------------------------------------
+
+    @Test
+    void returnsAnEmptyConfigWhenTheConfiguredFileDoesNotExistYet() throws IOException {
+        Map<String, Object> config = managerAt(configDir.resolve("does-not-exist.yaml").toString()).readApplicationYaml();
+
+        assertThat(config).isEmpty();
+    }
+}


### PR DESCRIPTION
`ConfigurationManager` resolves the config file it writes to from the Spring property
`spring.allConfig.location`:

```java
this.configPath = resolveConfigPath(environment.getProperty("spring.allConfig.location"));
```

That property does not exist. Nothing in the repository sets it, and it is not a Spring Boot
property, so `getProperty` always returns `null` and `resolveConfigPath` always takes its
hardcoded fallback branch. The effect is that the entire `resolveConfigPath` logic below the
null check — directory handling, the `file:` prefix strip, the comma-separated list handling —
is unreachable in practice.

This changes the lookup to `spring.config.location`, which is what the surrounding code is
clearly written for: stripping a `file:` prefix and taking the first entry of a comma-separated
list only makes sense for Boot's own config-location property.

### Tests

`ConfigurationManager` had no test coverage. This adds `ConfigurationManagerTest` (9 tests)
covering the resolution rules and the write path:

- location pointing at a file, and at a directory
- `file:` prefix stripped
- first entry taken from a comma-separated list
- writes land in the configured location
- nested keys are written without discarding siblings
- `updateProperties` writes once and publishes one `ConfigurationChangedEvent`
- a missing config file yields an empty map (first-run onboarding)

The assertions key off a marker value that only exists in the test's `@TempDir`. That detail
matters: an earlier draft of these tests asserted on an `agent:` key and passed *before* the
fix, because with the typo in place the manager resolves the fallback path and reads the
repository's own `application.private.yaml`. Pinning to a unique marker makes the tests fail
without the fix, which they now do (8 of 9 red before, all green after).

### Scope, and two things left out on purpose

Deliberately limited to the property name.

While writing the tests I ran into a related but separate problem: the location this manager
*writes* to and the location Boot *reads* private config from are not the same, so onboarding
does not persist in a packaged jar or in the Docker image. That is a design question rather
than a typo, so I am filing it as its own issue rather than growing this PR.

Making the property live for the first time also exposes two pre-existing gaps in
`resolveConfigPath`, which this PR does not touch. Flagging them so they are a known choice
rather than a surprise:

- a `classpath:` location is not handled — only `file:` is stripped, so `Path.of("classpath:/…")`
  becomes a literal path that will not exist, and `readApplicationYaml` then quietly returns an
  empty map;
- `candidate.replace("file:", "")` replaces every occurrence rather than a leading prefix.

Happy to fix either here or in a follow-up, whichever you prefer.

Verified with `./gradlew test` (128 tests, 0 failures) and the Modulith / ArchUnit gates.
